### PR TITLE
fix(metadata): add validUntil property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:1.18.4"
 
     compileOnly 'org.projectlombok:lombok:1.18.4'
-    compileOnly 'org.slf4j:slf4j-api:1.6.1'
 
+    compile 'org.slf4j:slf4j-api:1.6.1'
     compile 'org.bouncycastle:bcprov-jdk15on:1.61'
     compile 'org.bouncycastle:bcpkix-jdk15on:1.61'
     compile 'ch.qos.logback:logback-classic:1.2.3'
@@ -29,6 +29,7 @@ dependencies {
 
     implementation 'org.codehaus.groovy:groovy-all:2.5.4'
     testImplementation 'org.spockframework:spock-core:1.2-groovy-2.5'
+    testCompile 'xmlunit:xmlunit:1.5'
 }
 
 
@@ -37,6 +38,7 @@ distributions {
         contents {
             into ''
             from("${buildDir}/resources/main/application.properties")
+            from("${buildDir}/resources/main/logback.xml")
             from("${buildDir}/resources/test/keycloak-example.xml")
         }
     }

--- a/e2e.sh
+++ b/e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-./gradlew  check  distZip
+./gradlew clean check distZip
 unzip -q -o build/distributions/bonita-saml-metadata.zip -d build/distributions
 
 cp e2e/keycloack-saml.xml build/distributions/bonita-saml-metadata/keycloak-example.xml
@@ -13,8 +13,10 @@ ls -l
 # check help
 bin/bonita-saml-metadata --help
 
-# check help
+# check generate
 bin/bonita-saml-metadata --properties ./application-signed.properties
+
+# check signed generate
 bin/bonita-saml-metadata --properties ./application-not-signed.properties
 
 ls -l sp-metadata.xml

--- a/e2e/application-not-signed.properties
+++ b/e2e/application-not-signed.properties
@@ -12,4 +12,8 @@ org.bonitasoft.endpoint = http://localhost:8080/bonita
 # if set to true will generate a self signed certificate
 org.bonitasoft.keystore.generate = false
 
-onelogin.saml2.unique_id_prefix = _
+# handle "validUntil" entityDescriptor attribute
+# provide a valid ISO date
+# due to current limitation of SAML lib, this attribute is
+# still mandatory
+org.bonitasoft.validUntil=2050-12-31T15:20:09Z

--- a/e2e/application-signed.properties
+++ b/e2e/application-signed.properties
@@ -8,6 +8,13 @@ org.bonitasoft.keycloak = keycloak-example.xml
 # bonita end point
 org.bonitasoft.endpoint = http://localhost:8080/bonita
 
+# handle "validUntil" entityDescriptor attribute
+# provide a valid ISO date
+# due to current limitation of SAML lib, this attribute is
+# still mandatory
+org.bonitasoft.validUntil=2050-12-31T15:20:09Z
+
+
 # generate self-signed certificate
 # if set to true will generate a self signed certificate
 org.bonitasoft.keystore.generate = true

--- a/src/main/groovy/org/bonitasoft/saml/metadata/App.groovy
+++ b/src/main/groovy/org/bonitasoft/saml/metadata/App.groovy
@@ -28,14 +28,15 @@ class App {
     public static final String PROPERTIES = "properties"
     public static final String HELP = "help"
 
+    public static final Logger logger = LoggerFactory.getLogger(App.class)
 
     String execute(Properties properties) {
-        Logger logger= LoggerFactory.getLogger(this.class)
+
         def endpoint = properties.get("org.bonitasoft.endpoint")
         def xmlKeyCloak = new File(properties.get("org.bonitasoft.keycloak")).text
 
         def samlModel = new SamlModel(xmlKeyCloak, endpoint)
-        def keyCloak = new KeyCloak(samlModel,properties,logger)
+        def keyCloak = new KeyCloak(samlModel, properties, logger)
         keyCloak.generateMetadata()
     }
 
@@ -50,7 +51,7 @@ class App {
             def propertyFile = "./application.properties"
             start(cmd, options, propertyFile)
         } catch (ParseException exp) {
-            System.err.println("ERROR: error while parsing arguments " + exp.getMessage())
+            System.err.logger.info("ERROR: error while parsing arguments " + exp.getMessage())
             HelpFormatter formatter = new HelpFormatter()
             formatter.printHelp("bonita-saml-metadata[.bat]", options)
             System.exit(1)
@@ -72,12 +73,12 @@ class App {
         if (!file.exists()) {
             throw new IllegalArgumentException("file does not exists ${file.getAbsolutePath()}")
         } else {
-            println "using property file ${file.getAbsolutePath()}"
+            logger.info "using property file ${file.getAbsolutePath()}"
         }
         Properties properties = new Properties()
         file.withInputStream { properties.load(it) }
 
-        properties. load(new FileInputStream(file.getAbsolutePath()))
+        properties.load(new FileInputStream(file.getAbsolutePath()))
         new App().execute(properties)
     }
 

--- a/src/main/groovy/org/bonitasoft/saml/metadata/App.groovy
+++ b/src/main/groovy/org/bonitasoft/saml/metadata/App.groovy
@@ -30,7 +30,7 @@ class App {
 
 
     String execute(Properties properties) {
-Logger logger= LoggerFactory.getLogger(this.class)
+        Logger logger= LoggerFactory.getLogger(this.class)
         def endpoint = properties.get("org.bonitasoft.endpoint")
         def xmlKeyCloak = new File(properties.get("org.bonitasoft.keycloak")).text
 

--- a/src/main/groovy/org/bonitasoft/saml/metadata/App.groovy
+++ b/src/main/groovy/org/bonitasoft/saml/metadata/App.groovy
@@ -19,6 +19,8 @@ import org.apache.commons.cli.DefaultParser
 import org.apache.commons.cli.HelpFormatter
 import org.apache.commons.cli.Options
 import org.apache.commons.cli.ParseException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 class App {
 
@@ -26,14 +28,15 @@ class App {
     public static final String PROPERTIES = "properties"
     public static final String HELP = "help"
 
-    String execute(Properties properties) {
-        def keyCloak = new KeyCloak()
 
+    String execute(Properties properties) {
+Logger logger= LoggerFactory.getLogger(this.class)
         def endpoint = properties.get("org.bonitasoft.endpoint")
         def xmlKeyCloak = new File(properties.get("org.bonitasoft.keycloak")).text
 
         def samlModel = new SamlModel(xmlKeyCloak, endpoint)
-        keyCloak.generateMetadata(samlModel, properties)
+        def keyCloak = new KeyCloak(samlModel,properties,logger)
+        keyCloak.generateMetadata()
     }
 
     static void main(String[] args) {

--- a/src/main/groovy/org/bonitasoft/saml/metadata/KeyCloak.groovy
+++ b/src/main/groovy/org/bonitasoft/saml/metadata/KeyCloak.groovy
@@ -86,6 +86,9 @@ class KeyCloak {
     }
 
     private Object getSamlProperty(String propertyName,boolean quiet=false) {
+        if (!samlProperties.containsKey(propertyName)){
+            throw new IllegalArgumentException("Property $propertyName is not set. Set a valid value and retry.")
+        }
         def value = samlProperties.get(propertyName)
         if (!quiet){
             logger.debug("$propertyName = $value")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,8 +5,9 @@ org.bonitasoft.keycloak = keycloak-example.xml
 org.bonitasoft.endpoint = http://localhost:8080/bonita
 
 # handle "validUntil" entityDescriptor attribute
-# keep empty to disable field
 # provide a valid ISO date
+# due to current limitation of SAML lib, this attribute is
+# still mandatory
 org.bonitasoft.validUntil=2050-12-31T15:20:09Z
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,14 @@
-# generated filename
-org.bonitasoft.metadata.dest_file = sp-metadata.xml
-
-
 # keycloak xml config file used in bonita tenant configuration
 org.bonitasoft.keycloak = keycloak-example.xml
 
 # bonita end point
 org.bonitasoft.endpoint = http://localhost:8080/bonita
+
+# handle "validUntil" entityDescriptor attribute
+# keep empty to disable field
+# provide a valid ISO date
+org.bonitasoft.validUntil=2050-12-31T15:20:09Z
+
 
 # generate self-signed certificate
 # if set to true will generate a self signed certificate

--- a/src/test/groovy/org/bonitasoft/saml/metadata/AppTest.groovy
+++ b/src/test/groovy/org/bonitasoft/saml/metadata/AppTest.groovy
@@ -13,13 +13,17 @@
  **/
 package org.bonitasoft.saml.metadata
 
-
+import org.custommonkey.xmlunit.DetailedDiff
+import org.custommonkey.xmlunit.Diff
+import org.custommonkey.xmlunit.XMLUnit
+import org.slf4j.Logger
 import spock.lang.Specification
 
 import java.nio.file.Files
 
-class AppTest extends Specification {
+class AppTest extends Specification implements SamlTestHelper {
 
+    Logger logger= org.slf4j.LoggerFactory.getLogger(this.class)
 
     def "should generate metadata"() {
         setup:
@@ -46,18 +50,68 @@ class AppTest extends Specification {
         def app = new App()
         Properties properties = new Properties()
         properties.load(this.class.getResourceAsStream("/application.properties"))
-
-
-        def xml = this.class.getResourceAsStream("/keycloak-example.xml").text
+        def xml = '''<keycloak-saml-adapter>
+    <SP entityID="http://entity-id.com:8081/path/"
+        sslPolicy="ALL"
+        nameIDPolicyFormat="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+        forceAuthentication="false"
+        isPassive="false"
+        turnOffChangeSessionIdOnLogin="true">
+        <Keys>
+            <Key signing="true" encryption="true">
+                <PrivateKeyPem>
+                    -----BEGIN PRIVATE KEY-----
+                    MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAN5Ub4dcUGWI4TGK8YPqIyxUuHlkyP+mFf7LV9gmyp1FhuIgdCfe9SpAUfpcf62XTy0emacIZUHSuCs4eprcen4YHJcSBNfOtmfYOrDjGtu45f5T5Q8uuDuGxizbxqll8Cid27UlewrUmG84n+V+LHR5vFHyNMXD+pW3gdDlp+klAgMBAAECgYEAyhH6EBASLkZ7TpkXK6spbshNpl+448pjYWIVpCqVqt2fW3TdvcNCFrXBDIj3rqHAX6TZSFw0E+BebUH3BTtww+oTUH6gLaQnYZ6roFjvBn59p6Sd9AGBUEMHV8oLewBUM5Qla/FlJnNBNU69VEcKhXugxb0PBDXij25fcQ1UqwECQQD66jmIyEPEUtILODwFnjQ8LrL37AHYi/+COOLidrHSyFtWTlne/9xPD75pbKEtiDOnUnvARhxWF8G38Igza7PBAkEA4tXoeN82DwAfHbr1MiO9Li1IMeUDUQBKSPvMu8rJLjzDRLPlD2MPBoEr3W145JzBa7uj00PejzQq24+VofF+ZQJAAd5Mn2AeYQ/c0IiSqdgLu4b9fisbuGkSdf3Gcrk/ibpEM9hRgv+UvGH5oP9WE+i3ub87fKsI+vsiTiRUX02mAQJBAIfFl3c5y4ahAP7vl7HiOGr6SZsrw5dpQA19Qecpks9tKUfnEXTrSuQOzu2jh9f2h8NvNbjPh9hZVknDIMIk5Q0CQFwKMW5r5MKtop6f/oDcqHixd0ukS2uEz+Q8hIL0zDX43urQvSrWC3bMSME5BFo5i7LYM0Kj1yn+Cq/gEll+koU=
+                    -----END PRIVATE KEY-----
+                </PrivateKeyPem>
+                <CertificatePem>
+                    -----BEGIN CERTIFICATE-----
+                    MIICLDCCAZWgAwIBAgIUdgYcPmghyMenrLkPRXjY0InAHDIwDQYJKoZIhvcNAQELBQAwFTETMBEGA1UEAwwKbG9jYWxob2hzdDAeFw0xOTA2MDcwMDAwMDBaFw0yMDA2MDYwMDAwMDBaMBUxEzARBgNVBAMMCmxvY2FsaG9oc3QwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAN5Ub4dcUGWI4TGK8YPqIyxUuHlkyP+mFf7LV9gmyp1FhuIgdCfe9SpAUfpcf62XTy0emacIZUHSuCs4eprcen4YHJcSBNfOtmfYOrDjGtu45f5T5Q8uuDuGxizbxqll8Cid27UlewrUmG84n+V+LHR5vFHyNMXD+pW3gdDlp+klAgMBAAGjeTB3MBsGA1UdDgQUMO92rn3+q4Cb6KtFA3JMo6y5gG8wGwYDVR0jBBQw73auff6rgJvoq0UDckyjrLmAbzAPBgNVHRMBAf8EBTADAQH/MAsGA1UdDwQEAwIChDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADgYEAbYC0PPLL+/JA0TXoNtyZ6y4CAegSk4yIIAsPD6lArcfydqlLTocaF+zhq0a627vAOm10DjXtDg1hknd2lGr1i/+hQeppYC2hUCixUvLrhnFu5Fl1Z0L3jojyRylQJzDx9cEtZkajFJNo44kKo50y9q3Bi+i8H4ld+ixsviSqRhM=
+                    -----END CERTIFICATE-----
+                </CertificatePem>
+            </Key>
+        </Keys>
+        <PrincipalNameMapping policy="FROM_ATTRIBUTE" attribute="Login"/>
+        <IDP entityID="https://xxxxxxx-xxxxxx.fr/xxxxx"
+             signaturesRequired="true"
+             signatureAlgorithm="RSA_SHA256">
+            <SingleSignOnService signRequest="true"
+                                 validateResponseSignature="true"
+                                 requestBinding="POST"
+                                 responseBinding="POST"
+                                 bindingUrl="https://xxxxxxx-xxxxxx.fr/xxx/xx/xx/SAML2/POST/SSO"/>
+            <SingleLogoutService signRequest="true"
+                                 signResponse="true"
+                                 validateRequestSignature="true"
+                                 validateResponseSignature="true"
+                                 requestBinding="POST"
+                                 responseBinding="POST"
+                                 postBindingUrl="https://xxxxxxx-xxxxxx.fr/xxx/xx/xx/SAML2/POST/SLO"
+                                 redirectBindingUrl="https://xxxxxxx-xxxxxx.fr/xxx/xx/xx/SAML2/Redirect/SLO"/>
+            <Keys>
+                <Key signing="true">
+                    <CertificatePem>
+                        -----BEGIN CERTIFICATE-----
+                        MIICLTCCAZagAwIBAgIVAIl9v+QFdmyQVFQ/0TZ5xka0vuiGMA0GCSqGSIb3DQEBCwUAMBUxEzARBgNVBAMMCmxvY2FsaG9oc3QwHhcNMTkwNjA3MDAwMDAwWhcNMjAwNjA2MDAwMDAwWjAVMRMwEQYDVQQDDApsb2NhbGhvaHN0MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCXCrZMIJcmDcPPOHr91JPsXAFhjlGepsacwjc5u+KJUjVlGCnKqQZWoa4G9OYERCnO31QjbaMcbkhBe/taDPmYru7O3XuPkbpOs5X+fzPqgCNK33fsrmsEd+TfM7kgZLKl+VPhhbgTxruLpZYSVmaXlVtNPrw9ENPHvdhQCGKtCwIDAQABo3kwdzAbBgNVHQ4EFL5z84+vwf9BTp2z9GtYfCesb19/MBsGA1UdIwQUvnPzj6/B/0FOnbP0a1h8J6xvX38wDwYDVR0TAQH/BAUwAwEB/zALBgNVHQ8EBAMCAoQwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA0GCSqGSIb3DQEBCwUAA4GBAIHoDLHXwbE5kuiShhe3AgEoY0szn56VThrTbjnF6tySL2OakzgfkcKFaR0yV2AeauUM9ie10Chy1Wz3zsx03V5juFRQ0bcp6hSWwIyyzkE7PfVzqFUkxLrD4qAsU5d5YOhFElrtVz1aGms8tZPpay+6IS8Ijv0gTpKCq0gtZjJK
+                        -----END CERTIFICATE-----
+                    </CertificatePem>
+                </Key>
+            </Keys>
+        </IDP>
+    </SP>
+</keycloak-saml-adapter>
+'''
         def file = Files.createTempFile("keycloak", ".xml").toFile()
         file.text = xml
         properties.setProperty("org.bonitasoft.keycloak", file.getAbsolutePath())
         def destFile = Files.createTempFile("metadata", ".xml").toFile()
         properties.setProperty("org.bonitasoft.metadata.dest_file", destFile.getAbsolutePath())
+        properties.setProperty("org.bonitasoft.metadata.dest_file", destFile.getAbsolutePath())
+        properties.setProperty("org.bonitasoft.keystore.generate", "false")
 
-        File props=Files.createTempFile("props",".properties").toFile()
+        File props = Files.createTempFile("props", ".properties").toFile()
         def stream = new FileOutputStream(props)
-        properties.store(stream,"")
+        properties.store(stream, "")
 
         String[] args = ["-p", props.getAbsolutePath()]
 
@@ -65,6 +119,78 @@ class AppTest extends Specification {
         App.main(args)
 
         then:
-        true
+        def expected = '''<?xml version="1.0"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2050-12-31T15:20:09Z"
+                     cacheDuration="PT2147483647S" entityID="http://entity-id.com:8081/path/" ID="_f0948d2e-05fd-482e-b4a5-b2ad3735ef37">
+    <md:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="false"
+                        protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:KeyDescriptor use="signing">
+            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>MIICLDCCAZWgAwIBAgIUdgYcPmghyMenrLkPRXjY0InAHDIwDQYJKoZIhvcNAQEL
+                        BQAwFTETMBEGA1UEAwwKbG9jYWxob2hzdDAeFw0xOTA2MDcwMDAwMDBaFw0yMDA2
+                        MDYwMDAwMDBaMBUxEzARBgNVBAMMCmxvY2FsaG9oc3QwgZ8wDQYJKoZIhvcNAQEB
+                        BQADgY0AMIGJAoGBAN5Ub4dcUGWI4TGK8YPqIyxUuHlkyP+mFf7LV9gmyp1FhuIg
+                        dCfe9SpAUfpcf62XTy0emacIZUHSuCs4eprcen4YHJcSBNfOtmfYOrDjGtu45f5T
+                        5Q8uuDuGxizbxqll8Cid27UlewrUmG84n+V+LHR5vFHyNMXD+pW3gdDlp+klAgMB
+                        AAGjeTB3MBsGA1UdDgQUMO92rn3+q4Cb6KtFA3JMo6y5gG8wGwYDVR0jBBQw73au
+                        ff6rgJvoq0UDckyjrLmAbzAPBgNVHRMBAf8EBTADAQH/MAsGA1UdDwQEAwIChDAd
+                        BgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADgYEA
+                        bYC0PPLL+/JA0TXoNtyZ6y4CAegSk4yIIAsPD6lArcfydqlLTocaF+zhq0a627vA
+                        Om10DjXtDg1hknd2lGr1i/+hQeppYC2hUCixUvLrhnFu5Fl1Z0L3jojyRylQJzDx
+                        9cEtZkajFJNo44kKo50y9q3Bi+i8H4ld+ixsviSqRhM=
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+        <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                     Location="http://localhost:8080/bonita/saml" index="1"/>
+    </md:SPSSODescriptor>
+</md:EntityDescriptor>'''
+        //destFile.text == expected
+
+        // def expectedXmlText = new File(this.class.getResource("/to7_4_0/$expectedXml").file).text
+        XMLUnit.setIgnoreWhitespace(true)
+        def xmlResult = destFile.text
+        logger.info """
+Result:
+*********
+$xmlResult
+*********
+"""
+        final List<Diff> allDifferences = new DetailedDiff(XMLUnit.compareXML(expected, xmlResult))
+                .getAllDifferences()
+        if (!allDifferences.isEmpty()) {
+            allDifferences.each { diff ->
+                //ignore @id attribute values generated at migration time
+                def description = diff.getProperties().get("description")
+                switch (description) {
+                    case "attribute value":
+                        def ignoreID = "ID"
+                        assert (diff.getProperties().get("controlNodeDetail") as org.custommonkey.xmlunit.NodeDetail).node.name == ignoreID
+                        assert (diff.getProperties().get("testNodeDetail") as org.custommonkey.xmlunit.NodeDetail).node.name == ignoreID
+                        break
+                    case "text value":
+                    //attribute id is here a text value
+                        def textNodeIds = ["ds:X509Certificate"]
+                        def controlNodeName = (diff.getProperties().get("controlNodeDetail") as org.custommonkey.xmlunit.NodeDetail).node.parentNode
+                        def testNodeName = (diff.getProperties().get("testNodeDetail") as org.custommonkey.xmlunit.NodeDetail).node.parentNode
+                        assert controlNodeName.name == testNodeName.name
+                    // this assertion is designed to display test node content when node name is not in expected textNodeIds
+                        logger.info("found difference in text node "+  testNodeName.name)
+                        assert textNodeIds.contains(testNodeName.name)// || controlNodeName.textContent == testNodeName.textContent
+
+                        assert sanitize(controlNodeName.textContent) == sanitize(testNodeName.textContent)
+                        break
+                    default:
+                        def testNodeName = (diff.getProperties().get("testNodeDetail") as org.custommonkey.xmlunit.NodeDetail).node
+                        logger.info "ERROR: $diff not expected! ***\n${testNodeName.textContent}\n***"
+                        assert diff == null
+                }
+
+            }
+        }
+
     }
 }

--- a/src/test/groovy/org/bonitasoft/saml/metadata/AppTest.groovy
+++ b/src/test/groovy/org/bonitasoft/saml/metadata/AppTest.groovy
@@ -29,8 +29,10 @@ class AppTest extends Specification {
 
         def xml = this.class.getResourceAsStream("/keycloak-example.xml").text
         def file = Files.createTempFile("keycloak", ".xml").toFile()
+        def destFile = Files.createTempFile("metadata", ".xml").toFile()
         file.text = xml
         properties.setProperty("org.bonitasoft.keycloak", file.getAbsolutePath())
+        properties.setProperty("org.bonitasoft.metadata.dest_file", destFile.getAbsolutePath())
 
         when:
         def result = app.execute(properties)
@@ -50,6 +52,8 @@ class AppTest extends Specification {
         def file = Files.createTempFile("keycloak", ".xml").toFile()
         file.text = xml
         properties.setProperty("org.bonitasoft.keycloak", file.getAbsolutePath())
+        def destFile = Files.createTempFile("metadata", ".xml").toFile()
+        properties.setProperty("org.bonitasoft.metadata.dest_file", destFile.getAbsolutePath())
 
         File props=Files.createTempFile("props",".properties").toFile()
         def stream = new FileOutputStream(props)

--- a/src/test/groovy/org/bonitasoft/saml/metadata/CertificateGeneratorTest.groovy
+++ b/src/test/groovy/org/bonitasoft/saml/metadata/CertificateGeneratorTest.groovy
@@ -14,6 +14,7 @@
 package org.bonitasoft.saml.metadata
 
 import org.bouncycastle.util.encoders.Base64
+import org.slf4j.Logger
 import spock.lang.Specification
 import spock.lang.Unroll
 import sun.security.provider.X509Factory
@@ -21,6 +22,8 @@ import sun.security.provider.X509Factory
 import java.security.KeyStore
 
 class CertificateGeneratorTest extends Specification {
+
+    Logger logger= org.slf4j.LoggerFactory.getLogger(this.class)
 
     @Unroll
     def "random certificate for alias #alias ans password #secret"(String secret,String alias) {
@@ -36,7 +39,7 @@ class CertificateGeneratorTest extends Specification {
         then:
         encodedKey != null
         encodedCertificate != null
-        println("""
+        logger.info("""
 
 alias: $alias
 password: $secret

--- a/src/test/groovy/org/bonitasoft/saml/metadata/KeyCloakTest.groovy
+++ b/src/test/groovy/org/bonitasoft/saml/metadata/KeyCloakTest.groovy
@@ -28,9 +28,13 @@ class KeyCloakTest extends Specification {
 
     @Unroll
     def "should parse #xmlFile"(xmlFile) {
+        def xmlContent1 = new File(this.class.getResource("/${xmlFile}").file).text
         given:
-        def samlModel = keyCloak.getModel(xmlFile, "http://example.com:1234/bonita")
+        def samlModel = new SamlModel(xmlContent1, "http://example.com:1234/bonita")
         Properties properties = new Properties()
+        def tempFile = Files.createTempFile("metadata", "xml").toFile()
+        properties.setProperty("org.bonitasoft.metadata.dest_file", tempFile.getAbsolutePath())
+
         properties.load(this.class.getResourceAsStream("/application.properties"))
         keyCloak = new KeyCloak(samlModel,properties,logger)
 
@@ -62,7 +66,5 @@ class KeyCloakTest extends Specification {
         then:
         def parsed = new XmlParser().parseText(xmlContent as String)
         parsed.@validUntil == "2050-12-31T15:20:09Z"
-
-
     }
 }

--- a/src/test/groovy/org/bonitasoft/saml/metadata/KeyCloakTest.groovy
+++ b/src/test/groovy/org/bonitasoft/saml/metadata/KeyCloakTest.groovy
@@ -63,7 +63,7 @@ class KeyCloakTest extends Specification {
         when:
         def xmlContent = keyCloak.generateMetadata()
 
-        then:
+        then: 'valid until is in generrated file'
         def parsed = new XmlParser().parseText(xmlContent as String)
         parsed.@validUntil == "2050-12-31T15:20:09Z"
     }

--- a/src/test/groovy/org/bonitasoft/saml/metadata/SamlModelTest.groovy
+++ b/src/test/groovy/org/bonitasoft/saml/metadata/SamlModelTest.groovy
@@ -15,16 +15,17 @@ package org.bonitasoft.saml.metadata
 
 import spock.lang.Specification
 
-class SamlModelTest extends Specification {
+class SamlModelTest extends Specification implements SamlTestHelper{
+
 
     def "should read certificate value from #xmlFileName"(xmlFileName) {
         given:
-        def xmlContent = new File(this.class.getResource("/$xmlFileName").file).text
+        def xmlContent = getXmlResourceContent(xmlFileName)
         SamlModel samlModel = new SamlModel(xmlContent, "http://localhost:1234/bonita")
 
         when:
         Node node = samlModel.rootNode
-        def value= node.SP.Keys.Key.CertificatePem.text()
+        def value = node.SP.Keys.Key.CertificatePem.text()
 
         then:
         value.contains "MIICLTCCAZagAwIBAgIVAKxgKaFfJtBGZpCiYXh"
@@ -33,17 +34,19 @@ class SamlModelTest extends Specification {
         xmlFileName << ["keycloak-example-keys.xml"]
     }
 
+
+
     def "should read attribute value from #xmlFileName"(xmlFileName) {
         given:
-        def xmlContent = new File(this.class.getResource("/$xmlFileName").file).text
+        def xmlContent = getXmlResourceContent(xmlFileName)
         SamlModel samlModel = new SamlModel(xmlContent, "http://localhost:1234/bonita")
 
         when:
         Node node = samlModel.rootNode
-        def value= node.SP.PrincipalNameMapping.@policy[0]
+        def value = node.SP.PrincipalNameMapping.@policy[0]
 
         then:
-        value=="FROM_ATTRIBUTE"
+        value == "FROM_ATTRIBUTE"
 
         where:
         xmlFileName << ["keycloak-example-keys.xml"]

--- a/src/test/groovy/org/bonitasoft/saml/metadata/SamlTestHelper.groovy
+++ b/src/test/groovy/org/bonitasoft/saml/metadata/SamlTestHelper.groovy
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2019 Bonitasoft S.A.
+ * Bonitasoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+package org.bonitasoft.saml.metadata
+
+trait SamlTestHelper {
+
+
+    public final static String EMPTY = ""
+    public final static String SPACE = " "
+
+    def getXmlResourceContent(xmlResourceFileName) {
+        new File(this.class.getResource("/$xmlResourceFileName").file).text
+    }
+
+    def sanitize(String keyContent) {
+        def result = keyContent.trim()
+        [SPACE, System.lineSeparator()].each {
+            result = result.replaceAll(it, EMPTY)
+        }
+        result as String
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -22,11 +22,11 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>%date %level %logger{20} %msg%n</pattern>
+            <pattern>%msg%n</pattern>
         </encoder>
     </appender>
 
-    <logger name="org.bonitasoft.saml" level="INFO"/>
+    <logger name="org.bonitasoft.saml" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/src/test/resources/metadata.xml
+++ b/src/test/resources/metadata.xml
@@ -1,5 +1,0 @@
-<md xmlns:md="urn:keycloak:saml:adapter" >
-
-</md>
-
-<!--    xml http://docs.oasis-open.org/security/saml/v2.0/saml-schema-metadata-2.0.xsd>-->


### PR DESCRIPTION
* allow to set a ISO date
* required, even if according to XSD attribute is optional

Relates to [#5](https://github.com/bonitasoft-presales/bonita-saml-metadata/issues/5)